### PR TITLE
Implement overlay for stories text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -197,6 +197,29 @@ body {
 #fb-stories .fb-stories-item .fb-box {
     border-radius: 8px;
     overflow: hidden;
+    position: relative;
+}
+
+#fb-stories .fb-stories-item .fb-bo {
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+}
+
+#fb-stories .fb-create-storie-area {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    padding: 8px;
+    color: var(--color-bg-white);
+    text-align: center;
+    background-color: rgba(0, 0, 0, 0.25);
+    transition: background-color 0.3s ease;
+}
+
+#fb-stories .fb-stories-item:hover .fb-create-storie-area {
+    background-color: rgba(0, 0, 0, 0.4);
 }
 
 #fb-stories .swiper {


### PR DESCRIPTION
## Summary
- ensure story boxes are positioned relatively
- overlay text within `.fb-create-storie-area`
- add smooth darkening effect on hover

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a581f35508321897df3a0c82ac817