### PR TITLE
Improve submenu usability and add profile image

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -165,13 +165,50 @@ body {
     margin-right: 15px;
     font-weight: bold;
 }
-.fb-user-actions li.fb-user span {
+.fb-user-actions li.fb-user .fb-user-img {
     border-radius: 50%;
     background-color: var(--color-bg);
     width: 30px;
     height: 30px;
     display: inline-block;
     margin-right: 5px;
+    object-fit: cover;
+}
+
+.fb-user-actions li {
+    position: relative;
+}
+
+.fb-user-actions .fb-submenu {
+    display: none;
+    position: absolute;
+    top: 45px;
+    right: 0;
+    background-color: var(--color-bg-white);
+    box-shadow: 0 0 10px #ccc;
+    border-radius: 8px;
+    width: 200px;
+    padding: 10px;
+    z-index: 10;
+}
+
+.fb-user-actions li:hover .fb-submenu,
+.fb-user-actions li .fb-submenu:hover {
+    display: block;
+}
+
+.fb-user-actions .fb-submenu ul {
+    list-style: none;
+    padding: 0;
+}
+
+.fb-user-actions .fb-submenu li {
+    display: block;
+    margin: 5px 0;
+}
+
+.fb-user-actions .fb-submenu a {
+    color: #000;
 }
 
 #fb-main {

--- a/index.html
+++ b/index.html
@@ -56,13 +56,38 @@
         <div class="fb-box fb-flex fb-justify-end">
           <div class="fb-user-actions">
             <ul class="fb-flex">
-              <li class="fb-user">
-                <a href="" class="fb-flex fb-align-center"> <span class="fb-user-img"></span> Willian </a>
+              <li class="fb-menu">
+                <a href="#"><i class="fas fa-bars"></i></a>
+                <div class="fb-submenu">
+                  <ul>
+                    <li><a href="#">Feed</a></li>
+                    <li><a href="#">Grupos</a></li>
+                    <li><a href="#">Marketplace</a></li>
+                  </ul>
+                </div>
               </li>
-              <li><a href="">link</a></li>
-              <li><a href="">link</a></li>
-              <li><a href="">link</a></li>
-              <li><a href="">link</a></li>
+              <li class="fb-messenger">
+                <a href="#"><i class="fab fa-facebook-messenger"></i></a>
+                <div class="fb-submenu">
+                  <p>Você não possui novas mensagens</p>
+                </div>
+              </li>
+              <li class="fb-notifications">
+                <a href="#"><i class="fas fa-bell"></i></a>
+                <div class="fb-submenu">
+                  <p>Sem novas notificações</p>
+                </div>
+              </li>
+              <li class="fb-user">
+                <a href="#"><img src="assets/img/naruto.jpg" alt="Foto de perfil" class="fb-user-img" /></a>
+                <div class="fb-submenu">
+                  <p>Conta de Willian</p>
+                  <ul>
+                    <li><a href="#">Configurações</a></li>
+                    <li><a href="#">Sair</a></li>
+                  </ul>
+                </div>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- keep dropdown visible when hovering submenu
- tweak submenu position
- show profile picture in user area

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a5775cd44832182ddf94488ff2dc2