### PR TITLE
Fix fb-user height and submenu position

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -165,6 +165,13 @@ body {
     margin-right: 15px;
     font-weight: bold;
 }
+.fb-user-actions li.fb-user a {
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    margin: 0 5px;
+}
+
 .fb-user-actions li.fb-user .fb-user-img {
     border-radius: 50%;
     background-color: var(--color-bg);
@@ -218,7 +225,7 @@ body {
 .fb-user-actions .fb-submenu {
     display: none;
     position: absolute;
-    top: 50px;
+    top: 45px;
     right: 0;
     background-color: var(--color-bg-white);
     box-shadow: 0 0 10px #ccc;


### PR DESCRIPTION
## Summary
- make fb-user anchor as tall as other links
- adjust user submenu positioning to avoid disappearing when hovering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a5e467bac8321aaaa51e2b8bb817f