### PR TITLE
Remove fixed heights from stories sections

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -282,9 +282,7 @@ body {
 
 #fb-stories .fb-user-image-stories {
     width: 100%;
-    height: 200px;
 }
-
 #fb-stories .fb-user-image-stories img,
 #fb-stories .fb-user-image-stories video {
     width: 100%;
@@ -325,9 +323,7 @@ body {
 
 #fb-stories .swiper-slide {
     display: flex;
-    height: 200px;
 }
-
 #fb-stories .swiper-button-next,
 #fb-stories .swiper-button-prev {
     color: var(--color-blue-h);


### PR DESCRIPTION
## Summary
- remove fixed height from `fb-user-image-stories` container
- remove fixed height from stories swiper slides

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a760112ac8321afa58ee9886c245a