### PR TITLE
Add submenu only to dot icon in posts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -368,12 +368,18 @@ body {
 }
 .fb-post-actions {
     position: relative;
+    display: flex;
+    align-items: center;
 }
 .fb-post-actions a {
     margin-left: 5px;
     color: #65676b;
 }
-.fb-post-actions .fb-submenu {
+.fb-post-menu {
+    position: relative;
+    display: inline-block;
+}
+.fb-post-menu .fb-submenu {
     display: none;
     position: absolute;
     top: 20px;
@@ -381,12 +387,27 @@ body {
     background-color: var(--color-bg-white);
     box-shadow: 0 0 10px #ccc;
     border-radius: 8px;
+    width: 220px;
     padding: 10px;
     z-index: 10;
 }
-.fb-post-actions:hover .fb-submenu,
-.fb-post-actions .fb-submenu:hover {
+.fb-post-menu:hover .fb-submenu,
+.fb-post-menu .fb-submenu:hover {
     display: block;
+}
+.fb-post-actions .fb-submenu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.fb-post-actions .fb-submenu li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 5px 0;
+}
+.fb-post-actions .fb-submenu li i {
+    color: #65676b;
 }
 .fb-post-body img,
 .fb-post-body video {

--- a/index.html
+++ b/index.html
@@ -172,14 +172,19 @@
                 </div>
               </div>
               <div class="fb-post-actions">
-                <a href="#"><i class="fas fa-ellipsis-h"></i></a>
-                <a href="#"><i class="fas fa-times"></i></a>
-                <div class="fb-submenu">
-                  <ul>
-                    <li><a href="#">Salvar postagem</a></li>
-                    <li><a href="#">Denunciar</a></li>
-                  </ul>
+                <div class="fb-post-menu">
+                  <a href="#" class="fb-menu-dots"><i class="fas fa-ellipsis-h"></i></a>
+                  <div class="fb-submenu">
+                    <ul>
+                      <li><a href="#"><i class="fas fa-star"></i> Adicionar aos favoritos</a></li>
+                      <li><a href="#"><i class="fas fa-bookmark"></i> Salvar postagem</a></li>
+                      <li><a href="#"><i class="fas fa-eye-slash"></i> Ocultar publicação</a></li>
+                      <li><a href="#"><i class="fas fa-bell-slash"></i> Desativar notificações</a></li>
+                      <li><a href="#"><i class="fas fa-flag"></i> Denunciar</a></li>
+                    </ul>
+                  </div>
                 </div>
+                <a href="#"><i class="fas fa-times"></i></a>
               </div>
             </header>
             <div class="fb-post-body">
@@ -206,14 +211,19 @@
                 </div>
               </div>
               <div class="fb-post-actions">
-                <a href="#"><i class="fas fa-ellipsis-h"></i></a>
-                <a href="#"><i class="fas fa-times"></i></a>
-                <div class="fb-submenu">
-                  <ul>
-                    <li><a href="#">Salvar postagem</a></li>
-                    <li><a href="#">Denunciar</a></li>
-                  </ul>
+                <div class="fb-post-menu">
+                  <a href="#" class="fb-menu-dots"><i class="fas fa-ellipsis-h"></i></a>
+                  <div class="fb-submenu">
+                    <ul>
+                      <li><a href="#"><i class="fas fa-star"></i> Adicionar aos favoritos</a></li>
+                      <li><a href="#"><i class="fas fa-bookmark"></i> Salvar postagem</a></li>
+                      <li><a href="#"><i class="fas fa-eye-slash"></i> Ocultar publicação</a></li>
+                      <li><a href="#"><i class="fas fa-bell-slash"></i> Desativar notificações</a></li>
+                      <li><a href="#"><i class="fas fa-flag"></i> Denunciar</a></li>
+                    </ul>
+                  </div>
                 </div>
+                <a href="#"><i class="fas fa-times"></i></a>
               </div>
             </header>
             <div class="fb-post-body">
@@ -241,14 +251,19 @@
                 </div>
               </div>
               <div class="fb-post-actions">
-                <a href="#"><i class="fas fa-ellipsis-h"></i></a>
-                <a href="#"><i class="fas fa-times"></i></a>
-                <div class="fb-submenu">
-                  <ul>
-                    <li><a href="#">Salvar postagem</a></li>
-                    <li><a href="#">Denunciar</a></li>
-                  </ul>
+                <div class="fb-post-menu">
+                  <a href="#" class="fb-menu-dots"><i class="fas fa-ellipsis-h"></i></a>
+                  <div class="fb-submenu">
+                    <ul>
+                      <li><a href="#"><i class="fas fa-star"></i> Adicionar aos favoritos</a></li>
+                      <li><a href="#"><i class="fas fa-bookmark"></i> Salvar postagem</a></li>
+                      <li><a href="#"><i class="fas fa-eye-slash"></i> Ocultar publicação</a></li>
+                      <li><a href="#"><i class="fas fa-bell-slash"></i> Desativar notificações</a></li>
+                      <li><a href="#"><i class="fas fa-flag"></i> Denunciar</a></li>
+                    </ul>
+                  </div>
                 </div>
+                <a href="#"><i class="fas fa-times"></i></a>
               </div>
             </header>
             <div class="fb-post-body">
@@ -276,14 +291,19 @@
                 </div>
               </div>
               <div class="fb-post-actions">
-                <a href="#"><i class="fas fa-ellipsis-h"></i></a>
-                <a href="#"><i class="fas fa-times"></i></a>
-                <div class="fb-submenu">
-                  <ul>
-                    <li><a href="#">Salvar postagem</a></li>
-                    <li><a href="#">Denunciar</a></li>
-                  </ul>
+                <div class="fb-post-menu">
+                  <a href="#" class="fb-menu-dots"><i class="fas fa-ellipsis-h"></i></a>
+                  <div class="fb-submenu">
+                    <ul>
+                      <li><a href="#"><i class="fas fa-star"></i> Adicionar aos favoritos</a></li>
+                      <li><a href="#"><i class="fas fa-bookmark"></i> Salvar postagem</a></li>
+                      <li><a href="#"><i class="fas fa-eye-slash"></i> Ocultar publicação</a></li>
+                      <li><a href="#"><i class="fas fa-bell-slash"></i> Desativar notificações</a></li>
+                      <li><a href="#"><i class="fas fa-flag"></i> Denunciar</a></li>
+                    </ul>
+                  </div>
                 </div>
+                <a href="#"><i class="fas fa-times"></i></a>
               </div>
             </header>
             <div class="fb-post-body">
@@ -310,14 +330,19 @@
                 </div>
               </div>
               <div class="fb-post-actions">
-                <a href="#"><i class="fas fa-ellipsis-h"></i></a>
-                <a href="#"><i class="fas fa-times"></i></a>
-                <div class="fb-submenu">
-                  <ul>
-                    <li><a href="#">Salvar postagem</a></li>
-                    <li><a href="#">Denunciar</a></li>
-                  </ul>
+                <div class="fb-post-menu">
+                  <a href="#" class="fb-menu-dots"><i class="fas fa-ellipsis-h"></i></a>
+                  <div class="fb-submenu">
+                    <ul>
+                      <li><a href="#"><i class="fas fa-star"></i> Adicionar aos favoritos</a></li>
+                      <li><a href="#"><i class="fas fa-bookmark"></i> Salvar postagem</a></li>
+                      <li><a href="#"><i class="fas fa-eye-slash"></i> Ocultar publicação</a></li>
+                      <li><a href="#"><i class="fas fa-bell-slash"></i> Desativar notificações</a></li>
+                      <li><a href="#"><i class="fas fa-flag"></i> Denunciar</a></li>
+                    </ul>
+                  </div>
                 </div>
+                <a href="#"><i class="fas fa-times"></i></a>
               </div>
             </header>
             <div class="fb-post-body">


### PR DESCRIPTION
## Summary
- restructure fb-post-actions to show submenu only when hovering the dots icon
- style submenu with icons and new layout

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a921082bc8321965f29b784fd6f1b