### PR TITLE
Add wrapper for post content

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -385,8 +385,13 @@ body {
 .fb-post-actions .fb-submenu:hover {
     display: block;
 }
-.fb-post-body img,
-.fb-post-body video {
+.fb-post-body-content {
+    max-height: 600px;
+    overflow: hidden;
+}
+
+.fb-post-body-content img,
+.fb-post-body-content video {
     width: 100%;
     margin: 10px 0;
     border-radius: 8px;

--- a/index.html
+++ b/index.html
@@ -183,7 +183,9 @@
               </div>
             </header>
             <div class="fb-post-body">
-              <p>Bom dia, pessoal! Espero que todos tenham uma ótima semana.</p>
+              <div class="fb-post-body-content">
+                <p>Bom dia, pessoal! Espero que todos tenham uma ótima semana.</p>
+              </div>
             </div>
             <div class="fb-post-info">
               <span><i class="fas fa-thumbs-up"></i> 120</span>
@@ -217,8 +219,10 @@
               </div>
             </header>
             <div class="fb-post-body">
-              <img src="https://images.pexels.com/photos/2014422/pexels-photo-2014422.jpeg" alt="Paisagem" />
-              <p>Olha essa paisagem incrível que encontrei!</p>
+              <div class="fb-post-body-content">
+                <img src="https://images.pexels.com/photos/2014422/pexels-photo-2014422.jpeg" alt="Paisagem" />
+                <p>Olha essa paisagem incrível que encontrei!</p>
+              </div>
             </div>
             <div class="fb-post-info">
               <span><i class="fas fa-heart"></i> <i class="fas fa-thumbs-up"></i> 456</span>
@@ -252,8 +256,10 @@
               </div>
             </header>
             <div class="fb-post-body">
-              <video src="https://videos.pexels.com/video-files/29309519/12638418_1080_1920_30fps.mp4" controls></video>
-              <p>Confiram esse vídeo incrível!</p>
+              <div class="fb-post-body-content">
+                <video src="https://videos.pexels.com/video-files/29309519/12638418_1080_1920_30fps.mp4" controls></video>
+                <p>Confiram esse vídeo incrível!</p>
+              </div>
             </div>
             <div class="fb-post-info">
               <span><i class="fas fa-thumbs-up"></i> 98</span>
@@ -287,7 +293,9 @@
               </div>
             </header>
             <div class="fb-post-body">
-              <p>Alguém recomenda séries para maratonar?</p>
+              <div class="fb-post-body-content">
+                <p>Alguém recomenda séries para maratonar?</p>
+              </div>
             </div>
             <div class="fb-post-info">
               <span><i class="fas fa-thumbs-up"></i> 30</span>
@@ -321,8 +329,10 @@
               </div>
             </header>
             <div class="fb-post-body">
-              <img src="https://images.pexels.com/photos/459225/pexels-photo-459225.jpeg" alt="Diversão com amigos" />
-              <p>Final de semana perfeito com amigos.</p>
+              <div class="fb-post-body-content">
+                <img src="https://images.pexels.com/photos/459225/pexels-photo-459225.jpeg" alt="Diversão com amigos" />
+                <p>Final de semana perfeito com amigos.</p>
+              </div>
             </div>
             <div class="fb-post-info">
               <span><i class="fas fa-heart"></i> <i class="fas fa-thumbs-up"></i> 300</span>


### PR DESCRIPTION
## Summary
- wrap each post's body in a `.fb-post-body-content` container
- cap media height via new `.fb-post-body-content` CSS rule

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a9069b88083218cfb9536bf0556c5